### PR TITLE
Thread fixes

### DIFF
--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -1,11 +1,12 @@
 import sys
 import math
+from typing import Any, Iterator
+
 import dxpy
 
-from typing import List, Any
 from typing.io import TextIO
 from concurrent import futures
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, Future
 
 
 class ThreadUtility:
@@ -31,12 +32,12 @@ class ThreadUtility:
             self._future_pool.append(self._executor.submit(class_type,
                                                            **kwargs))
 
-    def __next__(self):
+    def __next__(self) -> Any:
 
         self._check_and_format_progress_message()
-        next(self.future_iterator)
+        next(self._future_iterator).result()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Future[Any]]:
 
         self._already_collected = True
 
@@ -46,8 +47,8 @@ class ThreadUtility:
         print("{0:65}: {val}".format("Total number of threads to iterate through", val=self._num_jobs),
               file=self._output_writer)
 
-        self.future_iterator = futures.as_completed(self._future_pool)
-        return self.future_iterator
+        self._future_iterator = futures.as_completed(self._future_pool)
+        return self._future_iterator
 
     def _check_and_format_progress_message(self):
         self._total_finished_models += 1

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -46,7 +46,7 @@ class ThreadUtility:
         self._check_and_format_progress_message()
         return curr_future.result()
 
-    def __iter__(self) -> Iterator[Future]:
+    def __iter__(self) -> Iterator:
 
         self._already_collected = True
 

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -35,7 +35,7 @@ class ThreadUtility:
 
     # I have a feeling this is VERY inefficient but I am unsure of how to fix at the moment...
     def __next__(self) -> Any:
-
+        print('Is next called?')
         curr_future = next(self._future_iterator)
         while curr_future is None:
             curr_future = next(self._future_iterator)

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -1,5 +1,6 @@
 import sys
 import math
+from time import sleep
 from typing import Any, Iterator
 
 import dxpy
@@ -33,6 +34,9 @@ class ThreadUtility:
                                                            **kwargs))
 
     def __next__(self) -> Any:
+
+        while next(self._future_iterator) is None:
+            sleep(0)
 
         self._check_and_format_progress_message()
         next(self._future_iterator).result()

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -33,12 +33,14 @@ class ThreadUtility:
             self._future_pool.append(self._executor.submit(class_type,
                                                            **kwargs))
 
+    # I have a feeling this is VERY inefficient but I am unsure of how to fix at the moment...
     def __next__(self) -> Any:
 
         curr_future = next(self._future_iterator)
         while curr_future is None:
             curr_future = next(self._future_iterator)
             sleep(0.5)
+            print(curr_future)
 
         self._check_and_format_progress_message()
         curr_future.result()

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -37,6 +37,9 @@ class ThreadUtility:
         next(self.future_iterator)
 
     def __iter__(self):
+
+        self._already_collected = True
+
         if len(self._future_pool) == 0:
             raise dxpy.AppError('No jobs submitted to future pool!')
 
@@ -45,21 +48,6 @@ class ThreadUtility:
 
         self.future_iterator = futures.as_completed(self._future_pool)
         return self.future_iterator
-
-    def collect_futures(self) -> List[Any]:
-        self._already_collected = True
-
-        future_results = []
-        for future in futures.as_completed(self._future_pool):
-            try:
-                self._check_and_format_progress_message()
-                future_results.append(future.result())
-            except Exception as err:
-                print(self._error_message)
-                print(Exception, err)
-                raise dxpy.AppError(self._error_message)
-
-        return future_results
 
     def _check_and_format_progress_message(self):
         self._total_finished_models += 1

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -33,14 +33,13 @@ class ThreadUtility:
             self._future_pool.append(self._executor.submit(class_type,
                                                            **kwargs))
 
-    # I have a feeling this is VERY inefficient but I am unsure of how to fix at the moment...
+    # I have a feeling the sleep() part is VERY inefficient but I am unsure of how to fix at the moment...
     def __next__(self) -> Any:
 
         curr_future = next(self._future_iterator)
         while curr_future is None:
             curr_future = next(self._future_iterator)
-            sleep(0.5)
-            print(curr_future)
+            sleep(0.1)
 
         self._check_and_format_progress_message()
         return curr_future.result()

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -36,6 +36,8 @@ class ThreadUtility:
     # I have a feeling the sleep() part is VERY inefficient but I am unsure of how to fix at the moment...
     def __next__(self) -> Any:
 
+        # Due to how futures work, most of the time a next() call will recieve a 'None' return. We need to create a
+        # waiter that will hold until we get something OTHER than None, so we can return it to the main class.
         curr_future = next(self._future_iterator)
         while curr_future is None:
             curr_future = next(self._future_iterator)

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -37,7 +37,7 @@ class ThreadUtility:
         self._check_and_format_progress_message()
         next(self._future_iterator).result()
 
-    def __iter__(self) -> Iterator[Future[Any]]:
+    def __iter__(self) -> Iterator[Future]:
 
         self._already_collected = True
 

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -35,11 +35,13 @@ class ThreadUtility:
 
     def __next__(self) -> Any:
 
-        while next(self._future_iterator) is None:
-            sleep(0)
+        curr_future = next(self._future_iterator)
+        while curr_future is None:
+            curr_future = next(self._future_iterator)
+            sleep(0.5)
 
         self._check_and_format_progress_message()
-        next(self._future_iterator).result()
+        curr_future.result()
 
     def __iter__(self) -> Iterator[Future]:
 

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -35,7 +35,7 @@ class ThreadUtility:
 
     # I have a feeling this is VERY inefficient but I am unsure of how to fix at the moment...
     def __next__(self) -> Any:
-        print('Is next called?')
+
         curr_future = next(self._future_iterator)
         while curr_future is None:
             curr_future = next(self._future_iterator)
@@ -43,7 +43,7 @@ class ThreadUtility:
             print(curr_future)
 
         self._check_and_format_progress_message()
-        curr_future.result()
+        return curr_future.result()
 
     def __iter__(self) -> Iterator[Future]:
 

--- a/general_utilities/thread_utility/thread_utility.py
+++ b/general_utilities/thread_utility/thread_utility.py
@@ -48,7 +48,7 @@ class ThreadUtility:
               file=self._output_writer)
 
         self._future_iterator = futures.as_completed(self._future_pool)
-        return self._future_iterator
+        return self
 
     def _check_and_format_progress_message(self):
         self._total_finished_models += 1


### PR DESCRIPTION
Modifies how ThreadUtility collects futures. Now we use the generic __iter__ and __next__ methods. This is to ensure that large futures are not stored in memory and are instead gced()