### PR TITLE
small change for filterbcf run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /general_utilities.egg-info/
 /.talismanrc
 /sub_package.toml
+poetry.lock
+.idea/

--- a/general_utilities/job_management/command_executor.py
+++ b/general_utilities/job_management/command_executor.py
@@ -294,15 +294,22 @@ class CommandExecutor:
             return proc_exit_code
 
 
-def build_default_command_executor() -> CommandExecutor:
+def build_default_command_executor(dna_nexus_run: bool = True) -> CommandExecutor:
     """Set up the 'CommandExecutor' class, which handles downloading a Docker image, building the appropriate
     file system mounts, and provides methods for running system calls.
 
     :return: A CommandExecutor object
     """
 
-    default_mounts = [DockerMount(Path('/home/dnanexus/'), Path('/test/'))]
-    cmd_executor = CommandExecutor(docker_image='egardner413/mrcepid-burdentesting:latest',
-                                   docker_mounts=default_mounts)
+    if dna_nexus_run:
+        default_mounts = [DockerMount(Path('/home/dnanexus/'), Path('/test/'))]
+        cmd_executor = CommandExecutor(docker_image='egardner413/mrcepid-burdentesting:latest',
+                                       docker_mounts=default_mounts)
+
+    else:
+
+        test_mount = DockerMount(Path(os.getcwd()), Path('/test/'))
+        cmd_executor = CommandExecutor(docker_image='egardner413/mrcepid-burdentesting:latest',
+                                   docker_mounts=[test_mount])
 
     return cmd_executor


### PR DESCRIPTION
I am working on making filterbcf run local tests. This is a small change to allow the build_default_command_executor function to build a local docker image (if running local tests) if the dna_nexus_run is set to false. I have set it as false by default, to ensure no other functionality gets affected. 