### PR TITLE
Patch for 1.5.2

### DIFF
--- a/general_utilities/association_resources.py
+++ b/general_utilities/association_resources.py
@@ -366,7 +366,7 @@ def find_dxlink(name: str, folder: str) -> dict:
     return dxlink
 
 
-def bgzip_and_tabix(file_path: Path, comment_char: str = None, skip_row: int = 0,
+def bgzip_and_tabix(file_path: Path, comment_char: str = ' ', skip_row: int = 0,
                     sequence_row: int = 1, begin_row: int = 2, end_row: int = 3) -> Tuple[Path, Path]:
     """Compress a file using bgzip and create a tabix index.
 

--- a/general_utilities/association_resources.py
+++ b/general_utilities/association_resources.py
@@ -389,6 +389,16 @@ def bgzip_and_tabix(file_path: Path, comment_char: str = None, skip_row: int = 0
 
     """
 
+    # Fix leading tab in header caused by index=True in DataFrame
+    with file_path.open("r") as f:
+        lines = f.readlines()
+
+    if lines and lines[0].startswith('\t'):
+        # only remove tab, not all whitespace
+        lines[0] = lines[0].lstrip('\t')
+        with file_path.open("w") as f:
+            f.writelines(lines)
+
     # Compress using pysam
     outfile_compress = f'{file_path}.gz'
     pysam.tabix_compress(str(file_path.absolute()), outfile_compress)
@@ -401,7 +411,6 @@ def bgzip_and_tabix(file_path: Path, comment_char: str = None, skip_row: int = 0
         LOGGER.error(f"Failed to index file {outfile_compress}: {e}. Check the bgzip_and_tabix command in "
                      f"general_utilities - it's likely that the header settings need to be adjusted for your "
                      f"file format")
-        raise
 
     return Path(outfile_compress), Path(f'{outfile_compress}.tbi')
 

--- a/general_utilities/association_resources.py
+++ b/general_utilities/association_resources.py
@@ -389,16 +389,6 @@ def bgzip_and_tabix(file_path: Path, comment_char: str = ' ', skip_row: int = 0,
 
     """
 
-    # Fix leading tab in header caused by index=True in DataFrame
-    with file_path.open("r") as f:
-        lines = f.readlines()
-
-    if lines and lines[0].startswith('\t'):
-        # only remove tab, not all whitespace
-        lines[0] = lines[0].lstrip('\t')
-        with file_path.open("w") as f:
-            f.writelines(lines)
-
     # Compress using pysam
     outfile_compress = f'{file_path}.gz'
     pysam.tabix_compress(str(file_path.absolute()), outfile_compress)

--- a/general_utilities/linear_model/linear_model.py
+++ b/general_utilities/linear_model/linear_model.py
@@ -6,7 +6,7 @@ import statsmodels.api as sm
 from pathlib import Path
 from typing import Tuple, List
 
-from importlib.resources import files
+from importlib_resources import files
 
 from general_utilities.association_resources import get_chromosomes
 from general_utilities.mrc_logger import MRCLogger

--- a/general_utilities/linear_model/proccess_model_output.py
+++ b/general_utilities/linear_model/proccess_model_output.py
@@ -1,4 +1,3 @@
-import os
 import csv
 import dxpy
 import pandas as pd

--- a/general_utilities/linear_model/staar_model.py
+++ b/general_utilities/linear_model/staar_model.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import List
-from importlib.resources import files
+from importlib_resources import files
 
 from general_utilities.job_management.command_executor import DockerMount, build_default_command_executor
 from job_management.command_executor import CommandExecutor

--- a/general_utilities/linear_model/staar_model.py
+++ b/general_utilities/linear_model/staar_model.py
@@ -3,8 +3,6 @@ from typing import List
 from importlib_resources import files
 
 from general_utilities.job_management.command_executor import DockerMount, build_default_command_executor
-from job_management.command_executor import CommandExecutor
-
 
 # Generate the NULL model for STAAR
 def staar_null(phenoname: str, is_binary: bool, sex: int, ignore_base: bool,

--- a/general_utilities/plot_lib/cluster_plotter.py
+++ b/general_utilities/plot_lib/cluster_plotter.py
@@ -1,11 +1,8 @@
-import random
 from abc import ABC
 from pathlib import Path
-from typing import Tuple, List
 
 import pandas as pd
 
-from general_utilities.association_resources import get_include_sample_ids
 from general_utilities.job_management.command_executor import CommandExecutor
 from general_utilities.plot_lib.plotter import Plotter
 

--- a/general_utilities/plot_lib/manhattan_plotter.py
+++ b/general_utilities/plot_lib/manhattan_plotter.py
@@ -5,7 +5,7 @@ import pandas as pd
 from typing import List
 from pathlib import Path
 
-from importlib.resources import files
+from importlib_resources import files
 
 from general_utilities.job_management.command_executor import CommandExecutor
 from general_utilities.plot_lib.cluster_plotter import ClusterPlotter

--- a/general_utilities/plot_lib/plotter.py
+++ b/general_utilities/plot_lib/plotter.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, Any
 
-from importlib.resources.abc import Traversable
+from importlib_resources.abc import Traversable
 
 from general_utilities.mrc_logger import MRCLogger
 from general_utilities.job_management.command_executor import CommandExecutor, DockerMount


### PR DESCRIPTION
backwards compatibility with burden and gwas - the pysam indexing command doesn't automatically remove whitespace/tabs from the header, which means the comment_char option doesn't work. Have removed whitespace manually. 